### PR TITLE
Reworked Registry

### DIFF
--- a/api/src/main/java/dev/lunaa/lunaversecore/api/attribute/StatEntry.java
+++ b/api/src/main/java/dev/lunaa/lunaversecore/api/attribute/StatEntry.java
@@ -1,5 +1,6 @@
 package dev.lunaa.lunaversecore.api.attribute;
 
+import dev.lunaa.lunaversecore.LunaverseApi;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
@@ -10,7 +11,7 @@ import java.util.Locale;
 public record StatEntry(StatType type, StatValue value) {
 
     public String serialize() {
-        return String.format("%s;%s;%s;%s", type.getKey(), value.value(), value().modifier().getSymbol(), value().format().name());
+        return String.format("%s;%s;%s;%s", LunaverseApi.getRegistry().getKeyFor(type), value.value(), value().modifier().getSymbol(), value().format().name());
     }
 
     public Component readableFormat(Locale locale) {

--- a/api/src/main/java/dev/lunaa/lunaversecore/api/entity/AbstractCustomEntity.java
+++ b/api/src/main/java/dev/lunaa/lunaversecore/api/entity/AbstractCustomEntity.java
@@ -1,7 +1,6 @@
 package dev.lunaa.lunaversecore.api.entity;
 
 import dev.lunaa.lunaversecore.api.registry.RegistryEntry;
-import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.jetbrains.annotations.NotNull;
@@ -31,11 +30,6 @@ public class AbstractCustomEntity implements CustomEntity {
     @Override
     public Optional<Consumer<? super Entity>> getSpawnFunction() {
         return Optional.ofNullable(spawnFunction);
-    }
-
-    @Override
-    public @NotNull NamespacedKey getKey() { // TODO: keys not directly in a RegistryEntry, instead registered with the original entry to the registry
-        return null;
     }
 
     @Override

--- a/api/src/main/java/dev/lunaa/lunaversecore/api/entity/AbstractCustomLivingEntity.java
+++ b/api/src/main/java/dev/lunaa/lunaversecore/api/entity/AbstractCustomLivingEntity.java
@@ -7,6 +7,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.function.Consumer;
 
+@SuppressWarnings("UnstableApiUsage")
 public abstract class AbstractCustomLivingEntity extends AbstractCustomEntity implements CustomLivingEntity {
 
     private final double maxHealth;

--- a/api/src/main/java/dev/lunaa/lunaversecore/api/registry/BuiltinRegistries.java
+++ b/api/src/main/java/dev/lunaa/lunaversecore/api/registry/BuiltinRegistries.java
@@ -1,0 +1,14 @@
+package dev.lunaa.lunaversecore.api.registry;
+
+import dev.lunaa.lunaversecore.LunaverseApi;
+import dev.lunaa.lunaversecore.api.attribute.StatType;
+import dev.lunaa.lunaversecore.api.entity.CustomEntity;
+import dev.lunaa.lunaversecore.api.item.base.CustomItemBase;
+
+public class BuiltinRegistries {
+
+    public static final Registry<CustomItemBase> ITEM = LunaverseApi.getRegistry();
+    public static final Registry<StatType> STAT_TYPE = LunaverseApi.getRegistry();
+    public static final Registry<CustomEntity> ENTITY = LunaverseApi.getRegistry();
+
+}

--- a/api/src/main/java/dev/lunaa/lunaversecore/api/registry/Registry.java
+++ b/api/src/main/java/dev/lunaa/lunaversecore/api/registry/Registry.java
@@ -8,8 +8,16 @@ public interface Registry<T extends RegistryEntry> {
 
     Optional<T> get(NamespacedKey key);
 
-    boolean register(T entry);
+    Optional<T> get(String key);
 
-    boolean register(T entry, boolean overwrite);
+    Optional<NamespacedKey> getKeyFor(T entry);
+
+    boolean register(NamespacedKey key, T entry);
+
+    boolean register(String key, T entry);
+
+    boolean register(NamespacedKey key, T entry, boolean overwrite);
+
+    boolean register(String key, T entry, boolean overwrite);
 
 }

--- a/api/src/main/java/dev/lunaa/lunaversecore/api/registry/RegistryEntry.java
+++ b/api/src/main/java/dev/lunaa/lunaversecore/api/registry/RegistryEntry.java
@@ -1,19 +1,6 @@
 package dev.lunaa.lunaversecore.api.registry;
 
-import net.kyori.adventure.key.Key;
-import org.bukkit.Keyed;
-import org.bukkit.NamespacedKey;
-import org.jetbrains.annotations.NotNull;
-
-public interface RegistryEntry extends Keyed {
-
-    @Override
-    default @NotNull Key key() {
-        return Keyed.super.key();
-    }
-
-    @Override
-    @NotNull NamespacedKey getKey();
+public interface RegistryEntry {
 
     RegistryEntry copy();
 

--- a/api/src/main/java/dev/lunaa/lunaversecore/api/registry/RegistryException.java
+++ b/api/src/main/java/dev/lunaa/lunaversecore/api/registry/RegistryException.java
@@ -1,0 +1,9 @@
+package dev.lunaa.lunaversecore.api.registry;
+
+public class RegistryException extends Exception {
+
+    public RegistryException(String message) {
+        super(message);
+    }
+
+}

--- a/plugin/src/main/java/dev/lunaa/lunaversecore/LunaverseCore.java
+++ b/plugin/src/main/java/dev/lunaa/lunaversecore/LunaverseCore.java
@@ -31,7 +31,7 @@ public final class LunaverseCore extends JavaPlugin {
 
     public static final RegistryImpl<RegistryEntry> registry = new RegistryImpl<>();
 
-    private static final String NAMESPACE = "lunaverse";
+    private static final String NAMESPACE = "lunaverse_core";
 
 
     @Override

--- a/plugin/src/main/java/dev/lunaa/lunaversecore/registry/RegistryImpl.java
+++ b/plugin/src/main/java/dev/lunaa/lunaversecore/registry/RegistryImpl.java
@@ -22,23 +22,48 @@ public class RegistryImpl<T extends RegistryEntry> implements Registry<T> {
     }
 
     @Override
-    public boolean register(T entry) {
-        return register(entry, true);
+    public Optional<T> get(String key) {
+        return get(NamespacedKey.fromString(key));
     }
 
     @Override
-    public boolean register(T entry, boolean overwrite) {
-        NamespacedKey key = entry.getKey();
+    public Optional<NamespacedKey> getKeyFor(T entry) {;
+        for (Map.Entry<NamespacedKey, T> registeredEntry : registeredEntries.entrySet()) {
+            if (registeredEntry.getValue().getClass().getName().equals(entry.getClass().getName())) {
+                return Optional.of(registeredEntry.getKey());
+            }
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public boolean register(NamespacedKey key, T entry) {
+        return register(key, entry, true);
+    }
+
+    @Override
+    public boolean register(String key, T entry) {
+        return register(NamespacedKey.fromString(key), entry);
+    }
+
+    @Override
+    public boolean register(NamespacedKey key, T entry, boolean overwrite) {
         if (!overwrite && registeredEntries.containsKey(key)) {
             LunaverseCore.getLunaLogger().debug("Duplicate: Entry with key " + key + " already registered - ignoring");
             return false;
         }
         boolean overwritten = registeredEntries.containsKey(key);
+        if (overwritten) LunaverseCore.getLunaLogger().debug("Duplicate: Entry with key " + key + " already registered - overwriting");
 
         registeredEntries.put(key, entry);
 
-        LunaverseCore.getLunaLogger().debug("Registered " + getRegistryEntryType(entry).getSimpleName() + " " + entry.getKey());
+        LunaverseCore.getLunaLogger().debug("Registered " + entry.getClass().getSimpleName() + " " + key.asString());
         return overwritten;
+    }
+
+    @Override
+    public boolean register(String key, T entry, boolean overwrite) {
+        return register(NamespacedKey.fromString(key), entry, overwrite);
     }
 
     private Class<? extends RegistryEntry> getRegistryEntryType(RegistryEntry entry) {

--- a/plugin/src/main/java/dev/lunaa/lunaversecore/registry/RegistryImpl.java
+++ b/plugin/src/main/java/dev/lunaa/lunaversecore/registry/RegistryImpl.java
@@ -27,7 +27,7 @@ public class RegistryImpl<T extends RegistryEntry> implements Registry<T> {
     }
 
     @Override
-    public Optional<NamespacedKey> getKeyFor(T entry) {;
+    public Optional<NamespacedKey> getKeyFor(T entry) {
         for (Map.Entry<NamespacedKey, T> registeredEntry : registeredEntries.entrySet()) {
             if (registeredEntry.getValue().getClass().getName().equals(entry.getClass().getName())) {
                 return Optional.of(registeredEntry.getKey());

--- a/plugin/src/main/java/dev/lunaa/lunaversecore/test/ItemCommand.java
+++ b/plugin/src/main/java/dev/lunaa/lunaversecore/test/ItemCommand.java
@@ -25,14 +25,15 @@ public class ItemCommand {
     private static Component getItemInfo(ItemStack item) {
         CustomItemBase customItem = ItemParser.getFrom(item).orElse(null);
         if (customItem == null) return Component.text("Not a custom item");
-        Component infoComponent = Component.text("Key: " + customItem.getKey());
-
+        Component infoComponent = Component.text("Key: " + LunaverseCore.getRegistry().getKeyFor(customItem).orElse(new NamespacedKey(LunaverseCore.getNamespace(), "invalid_key")).asString());
         Optional<Set<StatEntry>> statsOptional = ItemUtils.getStats(item);
         if (statsOptional.isEmpty()) return infoComponent;
         infoComponent = infoComponent.appendNewline().append(Component.text("Stats:"));
 
         for (StatEntry entry : statsOptional.get()) {
-            infoComponent = infoComponent.appendNewline().append(Component.text("- " + entry.type().getKey() + " : " + entry.value().ofString()));
+            infoComponent = infoComponent.appendNewline().append(
+                    Component.text("- " + LunaverseCore.getRegistry().getKeyFor(entry.type()).orElse(new NamespacedKey(LunaverseCore.getNamespace(), "invalid_key")).asString() + " : " + entry.value().ofString())
+            );
         }
 
         return infoComponent;

--- a/plugin/src/main/java/dev/lunaa/lunaversecore/test/ItemCommand.java
+++ b/plugin/src/main/java/dev/lunaa/lunaversecore/test/ItemCommand.java
@@ -7,6 +7,7 @@ import dev.lunaa.lunaversecore.LunaverseCore;
 import dev.lunaa.lunaversecore.api.attribute.StatEntry;
 import dev.lunaa.lunaversecore.api.item.base.CustomItemBase;
 import dev.lunaa.lunaversecore.api.registry.RegistryEntry;
+import dev.lunaa.lunaversecore.api.registry.RegistryException;
 import dev.lunaa.lunaversecore.common.util.ItemUtils;
 import dev.lunaa.lunaversecore.item.ItemParser;
 import io.papermc.paper.command.brigadier.CommandSourceStack;
@@ -49,7 +50,11 @@ public class ItemCommand {
                     return 0;
                 }
                 RegistryEntry entry = entryOptional.get();
-                player.getInventory().addItem(ItemParser.getItem( (CustomItemBase) entry, player.locale()));
+                try {
+                    player.getInventory().addItem(ItemParser.getItem((CustomItemBase) entry, player.locale()));
+                } catch (RegistryException e) {
+                    LunaverseCore.getLunaLogger().error(e);
+                }
 
                 return Command.SINGLE_SUCCESS;
             })


### PR DESCRIPTION
Closes #6 

- Changed how the registry works: Swapped `RegistryEntry#getKey` in favor of `Registry#getKeyFor` and handled accordingly.
- Added a `BuiltinRegistries` class for easier registry access on the api side
- Changed the namespace
- Cleaned up debugging messages